### PR TITLE
Fix layout when Adsense modifies main height

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -356,8 +356,8 @@ export default function Home() {
   );
 
   return (
-    <main className="flex flex-row items-center justify-between h-screen">
-      <div className="relative flex justify-center h-screen grow">
+    <main className="flex flex-row items-center justify-between min-h-screen">
+      <div className="relative flex justify-center min-h-screen grow">
         <div className="absolute top-0 left-0 w-full h-screen" id="map" />
         <div className="absolute h-12 max-w-full px-1 w-96 top-4 lg:top-32">
           <FoundSummary


### PR DESCRIPTION
## Summary
- make the main container use `min-h-screen` so height overrides don't collapse layout
- adjust the inner container similarly

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6870fff55ec8832f90449bfa39cd6a91